### PR TITLE
Set high sensitivity to make file watching on OS X tolerable

### DIFF
--- a/src/juxt/dirwatch.clj
+++ b/src/juxt/dirwatch.clj
@@ -13,7 +13,8 @@
       :author "Malcolm Sparks"
       :requires "JDK7"}
   juxt.dirwatch
-  (:import (java.io File)
+  (:import (com.sun.nio.file SensitivityWatchEventModifier)
+           (java.io File)
            (java.nio.file FileSystems Path StandardWatchEventKinds WatchEvent WatchKey WatchService)
            (java.util.concurrent Executors ThreadFactory TimeUnit)))
 
@@ -41,7 +42,10 @@
               (type StandardWatchEventKinds/ENTRY_CREATE)
               [StandardWatchEventKinds/ENTRY_CREATE
                StandardWatchEventKinds/ENTRY_DELETE
-               StandardWatchEventKinds/ENTRY_MODIFY]))
+               StandardWatchEventKinds/ENTRY_MODIFY])
+             (into-array
+              (type SensitivityWatchEventModifier/HIGH)
+              [SensitivityWatchEventModifier/HIGH]))
   (doseq [^File dir (.. path toAbsolutePath toFile listFiles)]
     (when (. dir isDirectory)
           (register-path ws (. dir toPath) event-atom))


### PR DESCRIPTION
Without this setting, it would take 5-10 seconds on OS X for an event to be reported.

A caveat of this is that `com.sun.nio.file.SensitivityWatchEventModifier` is an internal api that might be removed in the future and require the `jdk.unsupported`
module to be added, see https://openjdk.java.net/jeps/260.

As of today it works in JDK 8 through 15.